### PR TITLE
Add support for RegExp in relaxerror

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ remoteFiles: "validation-files.json"
 Type: `Array` <br/>
 Default value: ``
 
-Helps to skip certain w3c errors messages from validation. Give exact error message in an array & validator will ignore those relaxed errors from validation. 
+Helps to skip certain w3c errors messages from validation. Give exact error message or a regular expression in an array & validator will ignore those relaxed errors from validation. 
 
 ```js
-relaxerror: ["Bad value X-UA-Compatible for attribute http-equiv on element meta.","Element title must not be empty."]
+relaxerror: ["Bad value X-UA-Compatible for attribute http-equiv on element meta.","document type does not allow element \"[A-Z]+\" here"]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 Report issues [here](https://github.com/praveenvijayan/grunt-html-validation/issues)
 
 ## Release History
+ * 2013-11-22   v0.1.9   Fix some bugs
  * 2013-11-22   v0.1.8   Added options for specify doctype and charset
  * 2013-11-22   v0.1.7   Added support for RegExp in relaxed validation
  * 2013-08-31   v0.1.6   Added relaxed validation, w3cjs updated from 0.1.9 to 0.1.10.  

--- a/README.md
+++ b/README.md
@@ -106,6 +106,86 @@ Helps to skip certain w3c errors messages from validation. Give exact error mess
 relaxerror: ["Bad value X-UA-Compatible for attribute http-equiv on element meta.","document type does not allow element \"[A-Z]+\" here"]
 ```
 
+#### options.doctype
+Type: `String` <br/>
+Default value: `false`
+
+Set `false` for autodetect or chose one of this options:
+
+- ``HTML5``
+- ``XHTML 1.0 Strict``
+- ``XHTML 1.0 Transitional``
+- ``XHTML 1.0 Frameset``
+- ``HTML 4.01 Strict``
+- ``HTML 4.01 Transitional``
+- ``HTML 4.01 Frameset``
+- ``HTML 4.01 + RDFa 1.1``
+- ``HTML 3.2``
+- ``HTML 2.0``
+- ``ISO/IEC 15445:2000 ("ISO HTML")``
+- ``XHTML 1.1``
+- ``XHTML + RDFa``
+- ``XHTML Basic 1.0``
+- ``XHTML Basic 1.1``
+- ``XHTML Mobile Profile 1.2``
+- ``XHTML-Print 1.0``
+- ``XHTML 1.1 plus MathML 2.0``
+- ``XHTML 1.1 plus MathML 2.0 plus SVG 1.1``
+- ``MathML 2.0``
+- ``SVG 1.0``
+- ``SVG 1.1``
+- ``SVG 1.1 Tiny``
+- ``SVG 1.1 Basic``
+- ``SMIL 1.0``
+- ``SMIL 2.0``
+
+
+#### options.charset
+Type: `String` <br/>
+Default value: `false`
+
+Set `false` for autodetect or chose one of this options:
+
+- ``utf-8``
+- ``utf-16``
+- ``iso-8859-1``
+- ``iso-8859-2``
+- ``iso-8859-3``
+- ``iso-8859-4``
+- ``iso-8859-5``
+- ``iso-8859-6-i``
+- ``iso-8859-7``
+- ``iso-8859-8``
+- ``iso-8859-8-i``
+- ``iso-8859-9``
+- ``iso-8859-10``
+- ``iso-8859-11``
+- ``iso-8859-13``
+- ``iso-8859-14``
+- ``iso-8859-15``
+- ``iso-8859-16``
+- ``us-ascii``
+- ``euc-jp``
+- ``shift_jis``
+- ``iso-2022-jp``
+- ``euc-kr``
+- ``gb2312``
+- ``gb18030``
+- ``big5``
+- ``big5-HKSCS``
+- ``tis-620``
+- ``koi8-r``
+- ``koi8-u``
+- ``iso-ir-111``
+- ``macintosh``
+- ``windows-1250``
+- ``windows-1251``
+- ``windows-1252``
+- ``windows-1253``
+- ``windows-1254``
+- ``windows-1255``
+- ``windows-1256``
+- ``windows-1257``
 
 ### Usage Examples
 
@@ -135,6 +215,8 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 Report issues [here](https://github.com/praveenvijayan/grunt-html-validation/issues)
 
 ## Release History
+ * 2013-11-22   v0.1.8   Added options for specify doctype and charset
+ * 2013-11-22   v0.1.7   Added support for RegExp in relaxed validation
  * 2013-08-31   v0.1.6   Added relaxed validation, w3cjs updated from 0.1.9 to 0.1.10.  
  * 2013-08-31   v0.1.5   Added remote validation support. Max network error retry count.  
  * 2013-08-19   v0.1.4   Fixed issues. Added 'stoponerror' option, validation report added. 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Default file for storing validation information.
 Type: `String` <br/>
 Default value: `validation-report.json`
 
-Consolidated report in JSON format. 
+Consolidated report in JSON format, if reportpath is ``false`` it will not generated.
 
 #### options.stoponerror
 Type: `Boolean` <br/>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-html-validation",
   "description": "W3C html validaton grunt plugin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/praveenvijayan/grunt-html-validation",
   "author": {
     "name": "praveenvijayan",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-html-validation",
   "description": "W3C html validaton grunt plugin",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "homepage": "https://github.com/praveenvijayan/grunt-html-validation",
   "author": {
     "name": "praveenvijayan",
@@ -35,7 +35,7 @@
     "grunt": "~0.4.1"
   },
   "dependencies": {
-    "w3cjs": "~0.1.10",
+    "w3cjs": "git+https://github.com/magarcia/w3cjs.git#0.1.21",
     "colors": "~0.6.0",
     "request": "~2.27.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-html-validation",
   "description": "W3C html validaton grunt plugin",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "homepage": "https://github.com/praveenvijayan/grunt-html-validation",
   "author": {
     "name": "praveenvijayan",

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -240,8 +240,9 @@ module.exports = function(grunt) {
 		};
 
 		function checkRelaxError (error) {
-			if(options.relaxerror.indexOf(error) >= 0){
-				return true;
+			for(var i = 0, l = options.relaxerror.length; i < l; i++) {
+				var re = new RegExp(options.relaxerror[i], 'g');
+				if(re.test(error)) return true;
 			}
 		}
 

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -140,7 +140,7 @@ module.exports = function(grunt) {
 					// file: 'http://localhost:9001/010_gul006_business_landing_o2_v11.html',
 					output: 'json', // Defaults to 'json', other option includes html
 					doctype: options.doctype, // Defaults false for autodetect
-					charset: options.charset // Defaults false for autodetect
+					charset: options.charset, // Defaults false for autodetect
 					callback: function(res) {
 
 						// console.log(res)

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -64,7 +64,9 @@ module.exports = function(grunt) {
 			stoponerror: false,
 			remotePath: false,
 			maxTry: 3,
-			relaxerror:[]
+			relaxerror:[],
+			doctype: false, // Defaults false for autodetect
+			charset: false // Defaults false for autodetect
 		});
 
 		var done = this.async(),
@@ -137,6 +139,8 @@ module.exports = function(grunt) {
 					file: files[counter], // file can either be a local file or a remote file
 					// file: 'http://localhost:9001/010_gul006_business_landing_o2_v11.html',
 					output: 'json', // Defaults to 'json', other option includes html
+					doctype: options.doctype, // Defaults false for autodetect
+					charset: options.charset // Defaults false for autodetect
 					callback: function(res) {
 
 						// console.log(res)

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -218,7 +218,7 @@ module.exports = function(grunt) {
 						// depending on the output type, res will either be a json object or a html string
 						counter++;
 
-						if (counter === flen) {
+						if (options.reportpath && counter === flen) {
 							grunt.file.write(options.reportpath, JSON.stringify(reportArry));
 							console.log("Validation report generated: ".green + options.reportpath);
 							done();

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -83,7 +83,7 @@ module.exports = function(grunt) {
 			return files.map(function(file){
 				return options.remotePath + file;
 			});
-		}
+		};
 
 		//Reset current validation status and start from scratch.
 		if (options.reset) {
@@ -100,9 +100,9 @@ module.exports = function(grunt) {
 
 			for (var i = 0; i < status.length; i++) {
 				if(!checkRelaxError(status[i].message)){
-					relaxedReport.push(status[i])
-				};
-			};
+					relaxedReport.push(status[i]);
+				}
+			}
 
 			var report = {};
 			report.filename = fname;
@@ -153,9 +153,9 @@ module.exports = function(grunt) {
 							if(retryCount === options.maxTry){
 								counter++;
 								if(counter !==flen){
-									netErrorMsg += msg.nextfile
+									netErrorMsg += msg.nextfile;
 								}else{
-									netErrorMsg += msg.eof
+									netErrorMsg += msg.eof;
 								}
 								retryCount = 0;
 							}
@@ -167,12 +167,21 @@ module.exports = function(grunt) {
 
 						len = res.messages.length;
 
+						function setGreen (argument) {
+							readSettings[files[counter]] = true;
+							grunt.log.ok(msg.ok.green);
+
+							reportFilename = options.remoteFiles ? dummyFile[counter] : files[counter];
+							addToReport(reportFilename, false);
+						}
+
 						if (len) {
 							var errorCount = 0;
 
 							for (var prop in res.messages) {
+								var chkRelaxError;
 								if(isRelaxError){
-									var chkRelaxError = checkRelaxError(res.messages[prop].message);
+									chkRelaxError = checkRelaxError(res.messages[prop].message);
 								}
 
 								if(!chkRelaxError){
@@ -210,14 +219,6 @@ module.exports = function(grunt) {
 
 						}
 
-						function setGreen (argument) {
-							readSettings[files[counter]] = true;
-							grunt.log.ok(msg.ok.green);
-
-							reportFilename = options.remoteFiles ? dummyFile[counter] : files[counter];
-							addToReport(reportFilename, false);
-						}
-
 						grunt.file.write(options.path, JSON.stringify(readSettings));
 						// depending on the output type, res will either be a json object or a html string
 						counter++;
@@ -229,7 +230,7 @@ module.exports = function(grunt) {
 						}
 
 						if (options.remoteFiles) {
-							if(counter === flen) return;
+							if(counter === flen) { return; }
 
 							rval(dummyFile[counter], function(){
 								validate(files);
@@ -246,7 +247,7 @@ module.exports = function(grunt) {
 		function checkRelaxError (error) {
 			for(var i = 0, l = options.relaxerror.length; i < l; i++) {
 				var re = new RegExp(options.relaxerror[i], 'g');
-				if(re.test(error)) return true;
+				if(re.test(error)) { return true; }
 			}
 		}
 
@@ -256,12 +257,12 @@ module.exports = function(grunt) {
 		*/
 
 		if(!options.remotePath && options.remoteFiles){
-			console.log(msg.remotePathError)
+			console.log(msg.remotePathError);
 			return;
-		};
+		}
 
 		if(options.remotePath && options.remotePath !== ""){
-			files = makeFileList(files)
+			files = makeFileList(files);
 		}
 
 		if(options.remoteFiles){
@@ -281,7 +282,7 @@ module.exports = function(grunt) {
 
 			for (var i = 0; i < dummyFile.length; i++) {
 				files.push('_tempvlidation.html');
-			};
+			}
 
 			rval(dummyFile[counter], function(){
 				validate(files);


### PR DESCRIPTION
I added support for regular expresions in relaxerror validation. I need for some errors like `document type does not allow element \"DIV\" here` or `document type does not allow element \"UL\" here`, that can be represented by `document type does not allow element \"[A-Z]+\" here`
