### PR TITLE
Added template validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Type: `Boolean` <br/>
 Default value: `false`
 
 Enables template processing. Templates are assumed to be fragments of potentially valid HTML without
-<head> and <body> tags, in .html files. The validation process therefore wraps the template contents in the minimal boilerplate
+&lt;head&gt; and &lt;body&gt; tags, in .html files. The validation process therefore wraps the template contents in the minimal boilerplate
 header and footer code required to validate, writes the result to a temporary file and passes the file to the validator.
 
 Example template:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,66 @@ Helps to skip certain w3c errors messages from validation. Give exact error mess
 relaxerror: ["Bad value X-UA-Compatible for attribute http-equiv on element meta.","Element title must not be empty."]
 ```
 
+#### options.validatorurl
+Type: `String` <br/>
+Default value: `null`
+
+Allows you to set a different validator URL so that you can use a public mirror or an internal instance of the validator.
+You must provide the URL for the actual validation page i.e. it needs to end in "/check".
+
+If not set, defaults to http://validator.w3.org/check.
+
+```js
+validatorurl: "http://<your.validator.url>/check",
+```
+
+#### options.templates
+Type: `Boolean` <br/>
+Default value: `false`
+
+Enables template processing. Templates are assumed to be fragments of potentially valid HTML without
+<head> and <body> tags, in .html files. The validation process therefore wraps the template contents in the minimal boilerplate
+header and footer code required to validate, writes the result to a temporary file and passes the file to the validator.
+
+Example template:
+`
+			<div>
+				<span>Some content</span>
+				...
+			</div>
+`
+
+Wrapped template:
+`
+<!DOCTYPE HTML>
+	<html>
+		<head>
+			<title>-</title>
+		</head>
+		<body>
+			<div>
+				<span>Some content</span>
+				...
+			</div>
+		</body>
+</html>
+`
+
+```js
+templates: true
+```
+
+#### options.doctype
+Type: `String` <br/>
+Default value: `null`
+
+Allows you to set the doctype to use when wrapping templates.
+
+If not set, defaults to the HTML 5 doctype.
+
+```js
+doctype: '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
+```
 
 ### Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # grunt-html-validation [![Build Status](https://travis-ci.org/praveenvijayan/grunt-html-validation.png?branch=master)](https://travis-ci.org/praveenvijayan/grunt-html-validation)
 
 [![NPM](https://nodei.co/npm/grunt-html-validation.png?downloads=true)](https://nodei.co/npm/grunt-html-validation/)

--- a/README.md
+++ b/README.md
@@ -138,16 +138,16 @@ Example template:
 Wrapped template:
 ```html
 <!DOCTYPE HTML>
-	<html>
-		<head>
-			<title>-</title>
-		</head>
-		<body>
-			<div>
-				<span>Some content</span>
-				...
-			</div>
-		</body>
+<html>
+	<head>
+		<title>-</title>
+	</head>
+	<body>
+		<div>
+			<span>Some content</span>
+			...
+		</div>
+	</body>
 </html>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # grunt-html-validation [![Build Status](https://travis-ci.org/praveenvijayan/grunt-html-validation.png?branch=master)](https://travis-ci.org/praveenvijayan/grunt-html-validation)
 
 [![NPM](https://nodei.co/npm/grunt-html-validation.png?downloads=true)](https://nodei.co/npm/grunt-html-validation/)
@@ -129,15 +128,15 @@ Enables template processing. Templates are assumed to be fragments of potentiall
 header and footer code required to validate, writes the result to a temporary file and passes the file to the validator.
 
 Example template:
-`
+```html
 			<div>
 				<span>Some content</span>
 				...
 			</div>
-`
+```
 
 Wrapped template:
-`
+```html
 <!DOCTYPE HTML>
 	<html>
 		<head>
@@ -150,7 +149,7 @@ Wrapped template:
 			</div>
 		</body>
 </html>
-`
+```
 
 ```js
 templates: true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1"
+    "grunt": "~0.4.1",
+    "tmp": "0.0.21"
   },
   "dependencies": {
     "w3cjs": "~0.1.10",

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -12,9 +12,7 @@ module.exports = function(grunt) {
 
 	var w3cjs = require('w3cjs');
 	var colors = require('colors');
-	var fs = require('fs');
 	var path = require('path');
-	var request = require('request');
 	var rval = require('../lib/remoteval');
 
 	colors.setTheme({
@@ -31,9 +29,7 @@ module.exports = function(grunt) {
 		blue: 'blue'
 	});
 
-	var htmlContent = "",
-		arryFile = [],
-		counter = 0,
+	var counter = 0,
 		msg = {
 			error: "Something went wrong",
 			ok: "Validation successful..",
@@ -41,16 +37,13 @@ module.exports = function(grunt) {
 			networkError: 'Network error re-validating..'.error,
 			validFile: "Validated skipping..",
 			nofile: ":- No file is specified in the path!",
-			nextfile: "Skipping to next file..".verbose,
+			nextfile: "Skipping to the next file..".verbose,
 			eof: "End of File..".verbose,
 			fileNotFound: "File not found..".error,
-			remotePathError: "Remote path ".error + "(options->remotePath) ".grey + "is mandatory when remote files ".error+"(options-> remoteFiles) ".grey+"are specified!".error
+			remotePathError: "Remote path ".error + "(options->remotePath) ".grey + "is mandatory when remote files ".error+"(options-> remoteFiles) ".grey+"are specified!".error,
+			temp: "Using temp file: ".info
 		},
 		len,
-		fileStat = {},
-		isModified,
-		fileCount = 0,
-		validsettings = "",
 		reportArry =[],
 		retryCount = 0,
 		reportFilename = "";
@@ -64,24 +57,26 @@ module.exports = function(grunt) {
 			stoponerror: false,
 			remotePath: false,
 			maxTry: 3,
-			relaxerror:[]
+			relaxerror:[],
+			templates: false
 		});
 
 		var done = this.async(),
 			files = grunt.file.expand(this.filesSrc),
 			flen = files.length,
 			readSettings = {},
-			remoteArry = [],
 			isRelaxError = false;
 
 		isRelaxError = options.relaxerror.length && options.relaxerror.length !== '';
 
 		
 		var makeFileList  = function (files) {
-			return files.map(function(file){
+			return files.map(function(file) {
 				return options.remotePath + file;
 			});
-		}
+		};
+
+		var filenames = [];	// Stores the original names when temp files are used for templates.
 
 		//Reset current validation status and start from scratch.
 		if (options.reset) {
@@ -97,10 +92,10 @@ module.exports = function(grunt) {
 			var relaxedReport = [];
 
 			for (var i = 0; i < status.length; i++) {
-				if(!checkRelaxError(status[i].message)){
-					relaxedReport.push(status[i])
-				};
-			};
+				if (!checkRelaxError(status[i].message)) {
+					relaxedReport.push(status[i]);
+				}
+			}
 
 			var report = {};
 			report.filename = fname;
@@ -130,10 +125,16 @@ module.exports = function(grunt) {
 
 					var filename = options.remoteFiles ? dummyFile[counter] : files[counter];
 
-					console.log(msg.start + filename);
+					if (options.templates) {
+						console.log(msg.start + filenames[counter]);
+						console.log(msg.temp + filename);
+					}
+					else{
+						console.log(msg.start + filename);
+					}
 				}
 
-				var results = w3cjs.validate({
+				w3cjs.validate({
 					file: files[counter], // file can either be a local file or a remote file
 					// file: 'http://localhost:9001/010_gul006_business_landing_o2_v11.html',
 					output: 'json', // Defaults to 'json', other option includes html
@@ -146,18 +147,19 @@ module.exports = function(grunt) {
 						if (!res.messages) {
 							++retryCount;
 							var netErrorMsg = msg.networkError +  " " + retryCount.toString().error +" ";
-							if(retryCount === options.maxTry){
+							if (retryCount === options.maxTry) {
 								counter++;
-								if(counter !==flen){
-									netErrorMsg += msg.nextfile
+								if (counter !==flen) {
+									netErrorMsg += msg.nextfile;
 								}else{
-									netErrorMsg += msg.eof
+									netErrorMsg += msg.eof;
 								}
 								retryCount = 0;
 							}
 						
 							console.log(netErrorMsg);
 							validate(files);
+							deleteTmpFiles();
 							return;
 						}
 
@@ -165,16 +167,21 @@ module.exports = function(grunt) {
 
 						if (len) {
 							var errorCount = 0;
+							var chkRelaxError;
 
 							for (var prop in res.messages) {
-								if(isRelaxError){
-									var chkRelaxError = checkRelaxError(res.messages[prop].message);
+								if (isRelaxError) {
+									chkRelaxError = checkRelaxError(res.messages[prop].message);
 								}
 
-								if(!chkRelaxError){
+								if (!chkRelaxError) {
 									errorCount = errorCount+1;
 									console.log(errorCount + "=> ".warn + JSON.stringify(res.messages[prop].message).help +
-									" Line no: " + JSON.stringify(res.messages[prop].lastLine).prompt
+										" Line no: " + 
+										// If we're validating templates, adjust the line no. to allow for the 
+										// header boilerplate.
+										(options.templates ? JSON.stringify(res.messages[prop].lastLine - 6).prompt
+											: JSON.stringify(res.messages[prop].lastLine).prompt)
 									);
 								}
 								
@@ -182,7 +189,7 @@ module.exports = function(grunt) {
 
 
 
-							if(errorCount !== 0){
+							if (errorCount !== 0) {
 								console.log("No of errors: ".error + errorCount);
 							}
 							
@@ -191,11 +198,12 @@ module.exports = function(grunt) {
 							addToReport(reportFilename, res.messages);
 
 							if (options.stoponerror) {
+								deleteTmpFiles();
 								done();
 								return;
 							}
 
-							if(isRelaxError && errorCount === 0){
+							if (isRelaxError && errorCount === 0) {
 								setGreen();
 							}
 
@@ -206,7 +214,7 @@ module.exports = function(grunt) {
 
 						}
 
-						function setGreen (argument) {
+						function setGreen () {
 							readSettings[files[counter]] = true;
 							grunt.log.ok(msg.ok.green);
 
@@ -221,27 +229,41 @@ module.exports = function(grunt) {
 						if (counter === flen) {
 							grunt.file.write(options.reportpath, JSON.stringify(reportArry));
 							console.log("Validation report generated: ".green + options.reportpath);
+							
+							deleteTmpFiles();
 							done();
 						}
 
 						if (options.remoteFiles) {
-							if(counter === flen) return;
+							if (counter === flen) return;
 
-							rval(dummyFile[counter], function(){
+							rval (dummyFile[counter], function() {
 								validate(files);
 							});
 
 						}else{
 							validate(files);
-						}	
+						}
 					}
 				});
 			}
 		};
 
 		function checkRelaxError (error) {
-			if(options.relaxerror.indexOf(error) >= 0){
+			if (options.relaxerror.indexOf(error) >= 0) {
 				return true;
+			}
+		}
+		
+		// TEMPORARY SOLUTION UNTIL tmp CAN DELETE FILES ON CTRL-C... OR AT ALL.
+		function deleteTmpFiles () {
+			// Delete the temp files after validating templates.
+			if (options.templates) {
+				for (var i = 0;i < tplFiles.length;i++) {
+					if (grunt.file.exists(tplFiles[i])) {
+						grunt.file.delete(tplFiles[i], {force: true});
+					}
+				}
 			}
 		}
 
@@ -250,18 +272,18 @@ module.exports = function(grunt) {
 		* W3Cjs supports remote file validation but due to some reasons it is not working as expected. Local file validation is working perfectly. To overcome this remote page is fetch using 'request' npm module and write page content in '_tempvlidation.html' file and validates as local file. 
 		*/
 
-		if(!options.remotePath && options.remoteFiles){
-			console.log(msg.remotePathError)
+		if (!options.remotePath && options.remoteFiles) {
+			console.log(msg.remotePathError);
 			return;
-		};
-
-		if(options.remotePath && options.remotePath !== ""){
-			files = makeFileList(files)
 		}
 
-		if(options.remoteFiles){
+		if (options.remotePath && options.remotePath !== "") {
+			files = makeFileList(files);
+		}
 
-			if(typeof options.remoteFiles === 'object' && options.remoteFiles.length && options.remoteFiles[0] !=='' ){
+		if (options.remoteFiles) {
+
+			if (typeof options.remoteFiles === 'object' && options.remoteFiles.length && options.remoteFiles[0] !=='' ) {
 				files = options.remoteFiles;
 				
 			}else{
@@ -276,16 +298,58 @@ module.exports = function(grunt) {
 
 			for (var i = 0; i < dummyFile.length; i++) {
 				files.push('_tempvlidation.html');
-			};
+			}
 
-			rval(dummyFile[counter], function(){
+			rval (dummyFile[counter], function() {
 				validate(files);
 			});
 
 			return;
 		}
 
-		if(!options.remoteFiles){
+		if (options.templates) {
+			// Process HTML templates. Assumes that templates are fragments of potentially valid HTML without
+			// <head> and <body> tags. Therefore wraps the template contents in the minimal boilerplate
+			// header and footer required to validate.
+
+			var HTML5Header = "<!DOCTYPE HTML>\n<html>\n\t<head>\n\t\t<title>-</title>\n\t</head>\n\t<body>\n";
+			var HTML5Footer = "\n\t</body>\n</html>";
+			var tplFiles = [];
+			var responses = [];
+			
+			var tmp = require('tmp');
+			tmp.setGracefulCleanup();
+			
+			// Create a temp file for each template and valiate that. Temp files are created asynchronously
+			// so call val() to check the response state of each call and wait until all callbacks have returned.
+			for (var j = 0;j < files.length;j++) {
+				// Wrap the asynch. call in a function and pass the counter in to avoid the
+				// context changing before the call is made, causing the counter to change.
+				(function(j) {
+					tmp.tmpName({ postfix: '.html' }, function _tempNameGenerated(err, path) {
+						if (err) throw err;
+						var content = grunt.file.read(files[j]);
+						grunt.file.write(path, HTML5Header + content + HTML5Footer);
+						tplFiles[j] = path;
+						responses[j] = true;
+						val();
+					});
+				})(j);
+				filenames[j] = path.basename(files[j]);
+			}
+
+			// This function checks the response array and runs validation once all
+			// temp files are ready.
+			var val = function () {
+				if (tplFiles.length == files.length) {
+					validate(tplFiles);
+				}
+			};
+
+			return;
+		}
+
+		if (!options.remoteFiles) {
 			validate(files);
 		}
 


### PR DESCRIPTION
I've added support for validating templates such as those used by ng-boilerplate. Template code is wrapped in minimal boilerplate HTML and written to a temporary file. That file is then passed to the validator. I also added options to control which doctype is used and what URL is used for the validator. The latter applies to all usage, not just templates.
