### PR TITLE
Still complete when reportpath is false

### DIFF
--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -223,9 +223,11 @@ module.exports = function(grunt) {
 						// depending on the output type, res will either be a json object or a html string
 						counter++;
 
-						if (options.reportpath && counter === flen) {
-							grunt.file.write(options.reportpath, JSON.stringify(reportArry));
-							console.log("Validation report generated: ".green + options.reportpath);
+						if (counter === flen) {
+							if (options.reportpath) {
+								grunt.file.write(options.reportpath, JSON.stringify(reportArry));
+								console.log("Validation report generated: ".green + options.reportpath);
+							}
 							done();
 						}
 


### PR DESCRIPTION
Currently, tasks after `'validation'` in a `registeredTask` aren't executed if `options.reportpath` is `false`. This change calls `done` regardless.
