### PR TITLE
Add proxy option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ validation: {
 Type: `Boolean` <br/>
 Default value: `'false'`
 
+#### options.proxy
+Type: `String` <br/>
+Default value: `null`
+
+Setup your proxy when you are behind a corporate proxy and encounters `ETIMEDOUT`.
+
+```js
+proxy: 'http://proxy:8080'
+```
+
 Resets all the validated  files status. When want to revalidate all the validated files - 
 `eg: sudo grunt validate --reset=true`
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt": "~0.4.1"
   },
   "dependencies": {
-    "w3cjs": "~0.1.21",
+    "w3cjs": "~0.1.22",
     "colors": "~0.6.0",
     "request": "~2.27.0"
   },

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -61,6 +61,7 @@ module.exports = function(grunt) {
 			path: "validation-status.json",
 			reportpath: "validation-report.json",
 			reset: false,
+         proxy: null,
 			stoponerror: false,
 			remotePath: false,
 			maxTry: 3,
@@ -141,6 +142,7 @@ module.exports = function(grunt) {
 					output: 'json', // Defaults to 'json', other option includes html
 					doctype: options.doctype, // Defaults false for autodetect
 					charset: options.charset, // Defaults false for autodetect
+               proxy: options.proxy, // Proxy to pass to the w3c library
 					callback: function(res) {
 
 						// console.log(res)


### PR DESCRIPTION
Add a new proxy option in order to use the new proxy option available since w3cjs 0.1.22.
It can be useful when you are behind a corporate proxy.
