### PR TITLE
add failHard option; fixes #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ Set `false` for autodetect or chose one of this options:
 - ``windows-1256``
 - ``windows-1257``
 
+#### options.failHard
+Type: `boolean` <br/>
+Default value: `false`
+
+If true, the task will fail at the end of its run if there were any validation errors that were not ignored via `options.relaxerror`.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -62,6 +62,7 @@ module.exports = function(grunt) {
 			reportpath: "validation-report.json",
 			reset: false,
 			stoponerror: false,
+			failHard: false,
 			remotePath: false,
 			maxTry: 3,
 			relaxerror:[],
@@ -227,6 +228,12 @@ module.exports = function(grunt) {
 							if (options.reportpath) {
 								grunt.file.write(options.reportpath, JSON.stringify(reportArry));
 								console.log("Validation report generated: ".green + options.reportpath);
+							}
+							if (options.failHard) {
+							  var validationErrCount = reportArry.reduce(function (sum, report) { return sum + report.error.length; }, 0);
+							  if (validationErrCount > 0) {
+							    grunt.fail.warn(validationErrCount + " total unignored HTML validation error" + grunt.util.pluralize(validationErrCount, "/s") + ".");
+							  }
 							}
 							done();
 						}


### PR DESCRIPTION
Adds `options.failHard`, which lets the task validate all files but fails the task _at the end of the task's run_ if there were any validation errors.
We would like to use this option over at Bootstrap for our automated Travis builds.
Fixes #21 and https://github.com/twbs/bootstrap/issues/11876.
