### PR TITLE
Update dependencies and year of copyright

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,8 +7,8 @@
   "noarg": true,
   "sub": true,
   "undef": true,
+  "trailing": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
  * grunt-html-validation
  * https://github.com/praveen/grunt-html-validation
  *
- * Copyright (c) 2013 praveenvijayan
+ * Copyright (c) 2013 - 2014 praveenvijayan
  * Licensed under the MIT license.
  */
 
@@ -47,8 +47,8 @@ module.exports = function(grunt) {
             relaxerror: ["Bad value X-UA-Compatible for attribute http-equiv on element meta.","Element title must not be empty."]
         },
         files: {
-            src: ['test/html/*.html', 
-                '!test/html/index.html', 
+            src: ['test/html/*.html',
+                '!test/html/index.html',
                 '!test/html/404.html']
         }
     }

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2013 praveenvijayan
+Copyright (c) 2013 - 2014 praveenvijayan
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/_tempvlidation.html
+++ b/_tempvlidation.html
@@ -510,7 +510,7 @@ Accessibility</p>
   </div>
   <footer role="contentinfo"><p>
 
-  Copyright &copy; 2013 - Praveen Vijayan -
+  Copyright &copy; 2013 - 2014 Praveen Vijayan -
   <span class="credit">Powered by <a href="http://octopress.org">Octopress</a><a href="https://plus.google.com/112271602152550681222" rel="publisher" style="visibility: hidden">Google+</a></span>
 </p>
 

--- a/lib/remoteval.js
+++ b/lib/remoteval.js
@@ -18,9 +18,9 @@ module.exports = function remoteval (file, cb) {
 
 		if (!error && response.statusCode == 200) {
 			grunt.file.write('_tempvlidation.html',body);
-			return cb(true)
+			return cb(true);
 		}
-	})
+	});
 
 	
 }

--- a/lib/remoteval.js
+++ b/lib/remoteval.js
@@ -2,7 +2,7 @@
  * grunt-html-validation remote validation helper
  * https://github.com/praveen/grunt-html-validation
  *
- * Copyright (c) 2013 Praveen Vijayan
+ * Copyright (c) 2013 - 2014 Praveen Vijayan
  * Licensed under the MIT license.
  */
 module.exports = function remoteval (file, cb) {

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.1"
+    "grunt-contrib-jshint": "~0.8.0",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-nodeunit": "~0.2.2",
+    "grunt": "~0.4.2"
   },
   "dependencies": {
     "w3cjs": "~0.1.22",
     "colors": "~0.6.0",
-    "request": "~2.27.0"
+    "request": "~2.30.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -2,7 +2,7 @@
  * grunt-html-validation
  * https://github.com/praveen/grunt-html-validation
  *
- * Copyright (c) 2013 Praveen Vijayan
+ * Copyright (c) 2013 - 2014 Praveen Vijayan
  * Licensed under the MIT license.
  */
 'use strict';
@@ -125,7 +125,7 @@ module.exports = function (grunt) {
                     addToReport(reportFilename, false);
                     counter++;
                     validate(files);
-                    done()
+                    done();
                     return;
                 }
 


### PR DESCRIPTION
- I updated dependencies of this project and fixed JSHint settings. Now we don't need to set the ES5 option expressly.
  (cf. http://www.jshint.com/blog/2013-05-07/2-0-0/)
- I removed some trailing whitespaces and fixed missing semicolons.
- I updated the year of copyright from `2013` to `2013 - 2014`.
