### PR TITLE
Option to override default validator server

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Setup your proxy when you are behind a corporate proxy and encounters `ETIMEDOUT
 proxy: 'http://proxy:8080'
 ```
 
+#### options.serverUrl
+Type: `String` <br/>
+Default value: `null`
+
+Supply a different validator server URL, for instance [if you run a local server](http://validator.w3.org/source/).
+Eg: `http://localhost/w3c-validator/check`
+
 #### options.path
 Type: `String` <br/>
 Default value: `'validation-status.json'`

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -273,6 +273,11 @@ module.exports = function (grunt) {
                     w3cjs_options.file = files[counter];
                 }
 
+                // override default server
+                if (options.serverUrl) {
+                    w3cjs.setW3cCheckUrl(options.serverUrl);
+                }
+
                 var results = w3cjs.validate(w3cjs_options);
             }
         };


### PR DESCRIPTION
This feature is useful if you (like me) got blocked by w3 due to too many requests, or for whatever other reason choose to run a local instance of the validator service.
#### options.serverUrl

  Type: `String` <br/>
  Default value: `null`

 Supply a different validator server URL, for instance [if you run a local server](http://validator.w3.org/source/).
 Eg: `http://localhost/w3c-validator/check`
