### PR TITLE
Fix error of undefined file. Force return when no more files to check.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-html-validation",
   "description": "W3C html validation grunt plugin",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "homepage": "https://github.com/praveenvijayan/grunt-html-validation",
   "author": "praveenvijayan <praveenv.vijayan@gmail.com> (http://decodize.com)",
   "repository": {

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -110,6 +110,7 @@ module.exports = function (grunt) {
                 // fix: Fatal error: Unable to read 'undefined' file (Error code: ENOENT).
                 if (!files[counter]) {
                     done();
+                    return;
                 }
 
 


### PR DESCRIPTION
This PR fully fixes the error:

```
Fatal error: Unable to read 'undefined' file (Error code: ENOENT).
```

You call `done()`, but it doesn't fully end the `validate` function. The `return` ensures that it exits the function to end the grunt task.

I came across this error when linting 2 partial html files using the `wrapfile` option. My grunt config looked something like this:

``` js
validation: {
            options: {
                wrapfile: 'test/validation-wrap.html',
                reportpath: false,
                reset: true
            },
            files: {
                src: ['partials/**/*.html']
            }
        },
```
