### PR TITLE
prompt undefined fix

### DIFF
--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -191,10 +191,13 @@ module.exports = function (grunt) {
 
                                 if (!chkRelaxError) {
                                     errorCount = errorCount + 1;
-                                    console.log(errorCount + '=> '.warn + JSON.stringify(res.messages[prop].message).help +
-                                        (prompt ? ' Line no: ' + JSON.stringify(options.wrapfile ? res.messages[prop].unwrapLine : res.messages[prop].lastLine).prompt : 
-                                        ' Line no: ' + JSON.stringify(options.wrapfile ? res.messages[prop].unwrapLine : res.messages[prop].lastLine))
-                                    );
+
+                                    var lineNumber = ' Line no: ' + JSON.stringify(options.wrapfile ? res.messages[prop].unwrapLine : res.messages[prop].lastLine);
+                                    if (typeof(prompt) !== "undefined" && prompt) {
+                                        lineNumber = lineNumber.prompt;
+                                    }
+
+                                    console.log(errorCount + '=> '.warn + JSON.stringify(res.messages[prop].message).help + lineNumber );
                                 }
 
                             }

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -192,7 +192,8 @@ module.exports = function (grunt) {
                                 if (!chkRelaxError) {
                                     errorCount = errorCount + 1;
                                     console.log(errorCount + '=> '.warn + JSON.stringify(res.messages[prop].message).help +
-                                        ' Line no: ' + JSON.stringify(options.wrapfile ? res.messages[prop].unwrapLine : res.messages[prop].lastLine).prompt
+                                        (prompt ? ' Line no: ' + JSON.stringify(options.wrapfile ? res.messages[prop].unwrapLine : res.messages[prop].lastLine).prompt : 
+                                        ' Line no: ' + JSON.stringify(options.wrapfile ? res.messages[prop].unwrapLine : res.messages[prop].lastLine))
                                     );
                                 }
 

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -193,7 +193,7 @@ module.exports = function (grunt) {
                                     errorCount = errorCount + 1;
 
                                     var lineNumber = ' Line no: ' + JSON.stringify(options.wrapfile ? res.messages[prop].unwrapLine : res.messages[prop].lastLine);
-                                    if (typeof(prompt) !== "undefined" && prompt) {
+                                    if (typeof(prompt) !== 'undefined') {
                                         lineNumber = lineNumber.prompt;
                                     }
 


### PR DESCRIPTION
Hello when i tried this grunt task i have this error blocking me :

```
Fatal error: Cannot read property 'prompt' of undefined
```

I had to patch out the script in order to have execution. 
After the patch i have outputs like this :

```
1=> "& did not start a character reference. (& probably should have been escaped as &amp;.)" Line no: undefined
```

(the typo was on the title tag in the html, it seems it cannot get the line number > undefined)

I don't know why this happened or if this patch could be useful to you but anyway i report it to you.

Thanks for your code.
