### PR TITLE
Respect expand option

### DIFF
--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -66,7 +66,7 @@ module.exports = function (grunt) {
         });
 
         var done = this.async(),
-            files = grunt.file.expand(this.filesSrc),
+            files = this.files.expand ? grunt.file.expand(this.filesSrc) : this.filesSrc,
             flen = files.length,
             readSettings = {},
             isRelaxError = false;

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -12,7 +12,7 @@ module.exports = function (grunt) {
 
     var w3cjs = require('w3cjs');
     var colors = require('colors');
-    var chalk = require('chalk');
+    // var chalk = require('chalk');
     var rval = require('./lib/remoteval');
 
     colors.setTheme({


### PR DESCRIPTION
I was having some trouble running the validation on a site with a somewhat complicated structure. I think I pinpointed it to the way the package uses the 'expand' option. Here's a fix.

I also commented out an unused line of code so that the tests pass.
