### PR TITLE
fixes issue when using a remote path: files are not skipped anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Number of retries when network error occuers. Default case, after 3 reties valid
 Type: `String` <br/>
 Default value: ``
 
+#### options.tempPath
+Type: `String` <br/>
+Default value: ``
+
+When a remote path is used, this defines where the temporary html files are saved before they are validated.
+
 #### options.wrapfile
 Type: `String` <br/>
 Default value: ``

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -54,6 +54,7 @@ module.exports = function (grunt) {
         var options = this.options({
             path: 'validation-status.json',
             reportpath: 'validation-report.json',
+            tempPath: '',
             reset: false,
             proxy: null,
             stoponerror: false,
@@ -254,7 +255,7 @@ module.exports = function (grunt) {
                                 return;
                             }
 
-                            rval(dummyFile[counter], function () {
+                            rval(dummyFile[counter], options.remotePath, options.tempPath, function () {
                                 validate(files);
                             });
 
@@ -297,7 +298,7 @@ module.exports = function (grunt) {
          * Note on Remote validation.
          *  W3Cjs supports remote file validation but due to some reasons it is not working as expected.
          *  Local file validation is working perfectly. To overcome this remote page is fetch using 'request'
-         *  npm module and write page content in '_tempvlidation.html' file and validates as local file.
+         *  npm module and write page content in a local html file and validates it.
          */
 
         if (!options.remotePath && options.remoteFiles) {
@@ -325,10 +326,10 @@ module.exports = function (grunt) {
             files = [];
 
             for (var i = 0; i < dummyFile.length; i++) {
-                files.push('_tempvlidation.html');
+                files.push(options.tempPath + '/' + '_' + dummyFile[i].replace(options.remotePath, '') + '.html');
             }
 
-            rval(dummyFile[counter], function () {
+            rval(dummyFile[counter], options.remotePath, options.tempPath, function () {
                 validate(files);
             });
 

--- a/tasks/lib/remoteval.js
+++ b/tasks/lib/remoteval.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-module.exports = function remoteval (file, cb) {
+module.exports = function remoteval (file, remotePath, tempPath, cb) {
 
     var request = require('request');
     var grunt = require('grunt');
@@ -21,7 +21,7 @@ module.exports = function remoteval (file, cb) {
         }
 
         if (!error && response.statusCode === 200) {
-            grunt.file.write('_tempvlidation.html', body);
+            grunt.file.write(tempPath + '/' + '_' + file.replace(remotePath, '') + '.html', body);
             return cb(true);
         }
     });


### PR DESCRIPTION
This fixes the issue #64 
Rather than saving all the distant files in the same _tempvlidation.html file, it creates one separate temp file for each. I also added an option for the temporary path.
