### PR TITLE
Relaxerror can be exact string match

### DIFF
--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -286,7 +286,7 @@ module.exports = function (grunt) {
         function checkRelaxError(error) {
             for (var i = 0, l = options.relaxerror.length; i < l; i++) {
                 var re = new RegExp(options.relaxerror[i], 'g');
-                if (re.test(error)) {
+                if (re.test(error) || options.relaxerror[i] === error) {
                     return true;
                 }
             }

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -12,7 +12,6 @@ module.exports = function (grunt) {
 
     var w3cjs = require('w3cjs');
     var colors = require('colors');
-    var chalk = require('chalk');
     var rval = require('./lib/remoteval');
 
     colors.setTheme({


### PR DESCRIPTION
this patch allows relaxerror to be not just regular expression (previous functionality), but alternatively to match exactly the error string (new functionality)

this helps getting around confusing double escaping required when trying to silence the error `& did not start a character reference. (& probably should have been escaped as &amp;.)` (see discussion: http://stackoverflow.com/questions/15970738/did-not-start-a-character-reference-probably-should-have-been-escaped-as)

with regexp only, as before this PR, it is required to put into relaxerrors `\\& did not start a character reference. \\(\\& probably should have been escaped as \\&amp;.\\)`, which is a bit ugly
